### PR TITLE
View factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         }
     ],
     "require": {
-        "beberlei/assert": ">=1.5,<3",
         "php": ">=5.3"
     },
     "require-dev": {

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -9,23 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Shopery\View\Factory;
-
-use Shopery\View\View;
+namespace Shopery\View\Exception;
 
 /**
- * Interface ViewFactory
+ * Class InvalidArgumentException
+ *
+ * Thrown when an argument does not fulfill expectations
  *
  * @author Berny Cantos <be@rny.cc>
  */
-interface ViewFactory
+class InvalidArgumentException extends \InvalidArgumentException implements Exception
 {
-    /**
-     * Create a view for the object
-     *
-     * @param $object
-     *
-     * @return View
-     */
-    public function createView($object);
 }

--- a/src/Factory/CollectionViewFactory.php
+++ b/src/Factory/CollectionViewFactory.php
@@ -11,14 +11,17 @@
 
 namespace Shopery\View\Factory;
 
+use Traversable;
+
 use Shopery\View\View;
+use Shopery\View\View\CollectionView;
 
 /**
- * Interface ViewFactory
+ * Class CollectionViewFactory
  *
  * @author Berny Cantos <be@rny.cc>
  */
-interface ViewFactory
+class CollectionViewFactory implements ViewFactory
 {
     /**
      * Create a view for the object
@@ -27,5 +30,12 @@ interface ViewFactory
      *
      * @return View
      */
-    public function createView($object);
+    public function createView($object)
+    {
+        if (!($object instanceof Traversable)) {
+            return null;
+        }
+
+        return new CollectionView($object);
+    }
 }

--- a/src/Factory/CompositeViewFactory.php
+++ b/src/Factory/CompositeViewFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the shopery\view package
+ *
+ * (c) Berny Cantos <be@rny.cc>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopery\View\Factory;
+
+use Shopery\View\Exception\InvalidArgumentException;
+use Shopery\View\View;
+
+/**
+ * Class CompositeViewFactory
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class CompositeViewFactory implements ViewFactory
+{
+    /**
+     * @var ViewFactory[]
+     */
+    private $factories = [];
+
+    /**
+     * @param array|\Traversable $factories
+     */
+    public function __construct($factories)
+    {
+        foreach ($factories as $factory) {
+            if (!($factory instanceof ViewFactory)) {
+                throw new InvalidArgumentException(
+                    '"CompositeViewFactory" expects "ViewFactory" parameters'
+                );
+            }
+        }
+
+        $this->factories = $factories;
+    }
+
+    /**
+     * Create a view for the object, delegating to inner factories
+     *
+     * @param $object
+     *
+     * @return View
+     */
+    public function createView($object)
+    {
+        foreach ($this->factories as $factory) {
+            $view = $factory->createView($object);
+
+            if (null !== $view) {
+                return $view;
+            }
+        }
+    }
+}

--- a/src/Factory/ObjectViewFactory.php
+++ b/src/Factory/ObjectViewFactory.php
@@ -14,12 +14,22 @@ namespace Shopery\View\Factory;
 use Shopery\View\View;
 
 /**
- * Interface ViewFactory
+ * Class ObjectViewFactory
  *
  * @author Berny Cantos <be@rny.cc>
  */
-interface ViewFactory
+class ObjectViewFactory implements ViewFactory
 {
+    private $viewName;
+
+    /**
+     * @param string $viewName
+     */
+    public function __construct($viewName)
+    {
+        $this->viewName = $viewName;
+    }
+
     /**
      * Create a view for the object
      *
@@ -27,5 +37,10 @@ interface ViewFactory
      *
      * @return View
      */
-    public function createView($object);
+    public function createView($object)
+    {
+        $viewName = $this->viewName;
+
+        return new $viewName($object);
+    }
 }

--- a/src/Factory/RegistryViewFactory.php
+++ b/src/Factory/RegistryViewFactory.php
@@ -11,9 +11,6 @@
 
 namespace Shopery\View\Factory;
 
-use Assert\Assertion;
-
-use Shopery\View\Exception\UnsupportedObjectException;
 use Shopery\View\View;
 
 /**
@@ -29,6 +26,18 @@ class RegistryViewFactory implements ViewFactory
     private $registry = [];
 
     /**
+     * Constructor
+     *
+     * @param ViewFactory[] $factories
+     */
+    public function __construct($factories = [])
+    {
+        foreach ($factories as $className => $factory) {
+            $this->registerFactory($className, $factory);
+        }
+    }
+
+    /**
      * Register a factory in the abstract factory
      *
      * @param string $className
@@ -37,13 +46,11 @@ class RegistryViewFactory implements ViewFactory
      */
     public function registerFactory($className, ViewFactory $viewFactory)
     {
-        Assertion::string($className);
-
         $this->registry[$className] = $viewFactory;
     }
 
     /**
-     * Create a view for the object
+     * Create a view for the object, looking for a suitable factory
      *
      * @param $object
      *
@@ -51,10 +58,9 @@ class RegistryViewFactory implements ViewFactory
      */
     public function createView($object)
     {
-        Assertion::true(is_object($object), sprintf(
-            'Parameter must be an object, %s found',
-            gettype($object)
-        ));
+        if (!is_object($object)) {
+            return null;
+        }
 
         foreach ($this->registry as $className => $viewFactory) {
 
@@ -62,10 +68,5 @@ class RegistryViewFactory implements ViewFactory
                 return $viewFactory->createView($object);
             }
         }
-
-        throw new UnsupportedObjectException(sprintf(
-            'Can\'t create a View from object of class "%s"',
-            get_class($object)
-        ));
     }
 }

--- a/src/Factory/RootViewFactory.php
+++ b/src/Factory/RootViewFactory.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the shopery\view package
+ *
+ * (c) Berny Cantos <be@rny.cc>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopery\View\Factory;
+
+use Shopery\View\View;
+use Shopery\View\Exception;
+
+/**
+ * Class RootViewFactory
+ *
+ * Serves as a root for factories
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class RootViewFactory implements ViewFactory
+{
+    const NOT_FOUND_THROWS_EXCEPTION = 1;
+    const NOT_FOUND_RETURNS_NULL = 2;
+    const NOT_FOUND_RETURN_SOURCE = 3;
+
+    /**
+     * @var ViewFactory
+     */
+    private $factory;
+
+    /**
+     * @var int
+     */
+    private $notFoundBehaviour;
+
+    /**
+     * @param int $notFoundBehaviour What behaviour when a suitable view factory can't be found
+     */
+    public function __construct($notFoundBehaviour = self::NOT_FOUND_THROWS_EXCEPTION)
+    {
+        $this->notFoundBehaviour = $notFoundBehaviour;
+    }
+
+    /**
+     * @param ViewFactory $factory
+     *
+     * @return self
+     */
+    public function setFactory(ViewFactory $factory)
+    {
+        $this->factory = $factory;
+
+        return $this;
+    }
+
+    /**
+     * Create a view for the object, allows arrays recursively
+     *
+     * @param $object
+     *
+     * @return View
+     *
+     * @throws Exception\UnsupportedObjectException
+     */
+    public function createView($object)
+    {
+        if (is_array($object)) {
+            return array_map([ $this, 'createView' ], $object);
+        }
+
+        $view = $this->factory->createView($object);
+
+        if (false === $view instanceof View) {
+            return $this->notSuitableFactoryFor($object);
+        }
+
+        if ($view instanceof RootViewFactoryAware) {
+            $view->setRootViewFactory($this);
+        }
+
+        return $view;
+    }
+
+    /**
+     * Behaviour when a suitable view factory can't be found
+     *
+     * @param mixed $object
+     *
+     * @return null
+     */
+    private function notSuitableFactoryFor($object)
+    {
+        switch ($this->notFoundBehaviour) {
+            case self::NOT_FOUND_RETURNS_NULL:
+                return null;
+
+            case self::NOT_FOUND_RETURN_SOURCE:
+                return $object;
+
+            case self::NOT_FOUND_THROWS_EXCEPTION:
+            default:
+                throw new Exception\UnsupportedObjectException(sprintf(
+                    'Can\'t create a View from object of type "%s"',
+                    is_object($object) ? get_class($object) : gettype($object)
+                ));
+        }
+    }
+}

--- a/src/Factory/RootViewFactoryAware.php
+++ b/src/Factory/RootViewFactoryAware.php
@@ -11,21 +11,17 @@
 
 namespace Shopery\View\Factory;
 
-use Shopery\View\View;
-
 /**
- * Interface ViewFactory
+ * Interface RootViewFactoryAware
  *
  * @author Berny Cantos <be@rny.cc>
  */
-interface ViewFactory
+interface RootViewFactoryAware
 {
     /**
-     * Create a view for the object
+     * Called before a view is returned from `RootViewFactory`
      *
-     * @param $object
-     *
-     * @return View
+     * @param RootViewFactory $rootFactory
      */
-    public function createView($object);
+    public function setRootViewFactory(RootViewFactory $rootFactory);
 }

--- a/src/View/AbstractObjectView.php
+++ b/src/View/AbstractObjectView.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the shopery\view package
+ *
+ * (c) Berny Cantos <be@rny.cc>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopery\View\View;
+
+use Shopery\View\Factory\RootViewFactory;
+use Shopery\View\Factory\RootViewFactoryAware;
+use Shopery\View\View;
+
+/**
+ * Class AbstractObjectView
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+abstract class AbstractObjectView implements View, RootViewFactoryAware
+{
+    /**
+     * @var RootViewFactory
+     */
+    private $rootFactory;
+
+    /**
+     * @var mixed
+     */
+    protected $object;
+
+    /**
+     * @param mixed $object
+     */
+    protected function __construct($object)
+    {
+        $this->object = $object;
+    }
+
+    /**
+     * Create a view for an object
+     *
+     * @param $object
+     *
+     * @return View
+     */
+    protected function createViewFor($object)
+    {
+        return $this->rootFactory->createView($object);
+    }
+
+    /**
+     * Called before a view is returned from `RootViewFactory`
+     *
+     * @param RootViewFactory $rootFactory
+     */
+    public function setRootViewFactory(RootViewFactory $rootFactory)
+    {
+        $this->rootFactory = $rootFactory;
+    }
+}

--- a/src/View/CollectionView.php
+++ b/src/View/CollectionView.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the shopery\view package
+ *
+ * (c) Berny Cantos <be@rny.cc>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Shopery\View\View;
+
+use IteratorIterator;
+
+use Shopery\View\Factory\RootViewFactoryAware;
+use Shopery\View\Factory\RootViewFactory;
+use Shopery\View\View;
+
+/**
+ * Class CollectionView
+ *
+ * @author Berny Cantos <be@rny.cc>
+ */
+class CollectionView extends IteratorIterator implements View, RootViewFactoryAware
+{
+    /**
+     * @var RootViewFactory
+     */
+    private $rootFactory;
+
+    /**
+     * @param RootViewFactory $rootFactory
+     */
+    public function setRootViewFactory(RootViewFactory $rootFactory)
+    {
+        $this->rootFactory = $rootFactory;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function current()
+    {
+        return $this->rootFactory->createView(parent::current());
+    }
+}


### PR DESCRIPTION
- Introduces `RootViewFactory` as the root of all factories in the tree.
- Implement `RootViewFactoryAware` in your `View` to receive the root factory.
- Allow composability with `CompositeViewFactory`.
- Implementation for traversables in `CollectionViewFactory`.
- For simple views with no dependencies, `ObjectViewFactory` can do the work.
- Basic views can be created from `AbstractObjectView` as a base.

View definition:

``` php
class ProductView extends AbstractObjectView
{
    /**
     * @return Product
     */
    private function getProduct()
    {
        return $this->object; // From AbstractObjectView
    }

    public function getName()
    {
        return $this->getProduct()->getName();
    }

    public function getVariants()
    {
        return $this->createViewFor(
            $this->getProduct()->getVariants()
        );
    }
}
```

Initialization:

``` php
$root = new RootViewFactory();
$root->setFactory(
    new CompositeViewFactory([
        new RegistryViewFactory([
            Product::class => new ObjectViewFactory(ProductView::class),
            Variant::class => new ObjectViewFactory(VariantView::class),
        ]),
        new CollectionViewFactory(),
    ])
);
```

Usage:

``` php
/**
 * @var ProductView $view
 */
$view = $root->createView($product);

$name = $view->getName();
/** @var VariantView $variant */
foreach ($view->getVariants() as $variant) {
    $variantName = $variant->getName();
}
```
